### PR TITLE
Refactor comp player empty board

### DIFF
--- a/lib/comp_player.rb
+++ b/lib/comp_player.rb
@@ -1,7 +1,7 @@
 class CompPlayer
   def initialize; end
 
-  def get_move
+  def get_move(current_player)
     'a1'
   end
 end

--- a/lib/comp_player.rb
+++ b/lib/comp_player.rb
@@ -1,0 +1,7 @@
+class CompPlayer
+  def initialize; end
+
+  def get_move
+
+  end
+end

--- a/lib/comp_player.rb
+++ b/lib/comp_player.rb
@@ -2,6 +2,6 @@ class CompPlayer
   def initialize; end
 
   def get_move
-
+    'a1'
   end
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -13,7 +13,6 @@ class Game
   attr_reader :current_player
 
   def initialize
-    @player = CompPlayer.new
     @current_player = 1
     @mover = Mover.new
     @board = Board.new
@@ -39,7 +38,7 @@ class Game
 
   def game_loop
     loop do
-      move = mover.make_move(player: player, current_player: current_player)
+      move = mover.make_move(current_player)
 
       board.process_move(move: move, current_player: current_player)
 

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -5,7 +5,7 @@ require 'game_end_checker'
 class Game
   private
 
-  attr_reader :board, :game_end_checker, :mover
+  attr_reader :player, :board, :game_end_checker, :mover
   attr_writer :current_player
 
   public
@@ -13,6 +13,7 @@ class Game
   attr_reader :current_player
 
   def initialize
+    @player = CompPlayer.new
     @current_player = 1
     @mover = Mover.new
     @board = Board.new
@@ -38,7 +39,7 @@ class Game
 
   def game_loop
     loop do
-      move = mover.make_move(current_player)
+      move = mover.make_move(player: player, current_player: current_player)
 
       board.process_move(move: move, current_player: current_player)
 

--- a/lib/mover.rb
+++ b/lib/mover.rb
@@ -1,9 +1,9 @@
 class Mover
   def initialize; end
 
-  def make_move(player:, current_player:)
+  def make_move(current_player)
     loop do
-      move = player.get_move(current_player)
+      move = get_move(current_player)
 
       unless move.match(/^[a-c][1-3]$/)
         puts 'Your move was not recognized.'

--- a/lib/mover.rb
+++ b/lib/mover.rb
@@ -1,9 +1,9 @@
 class Mover
   def initialize; end
 
-  def make_move(current_player)
+  def make_move(player:, current_player:)
     loop do
-      move = get_move(current_player)
+      move = player.get_move(current_player)
 
       unless move.match(/^[a-c][1-3]$/)
         puts 'Your move was not recognized.'

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -5,7 +5,8 @@ class Player
     @comp_player = comp_player
   end
 
-  def get_move
-    'c2'
+  def get_move(current_player)
+    puts "Player #{current_player}, please enter your move (ex: b2)"
+    gets.chomp.downcase
   end
 end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,9 +1,5 @@
 class Player
-  attr_reader :comp_player
-
-  def initialize(comp_player)
-    @comp_player = comp_player
-  end
+  def initialize; end
 
   def get_move(current_player)
     puts "Player #{current_player}, please enter your move (ex: b2)"

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,0 +1,11 @@
+class Player
+  attr_reader :comp_player
+
+  def initialize(comp_player)
+    @comp_player = comp_player
+  end
+
+  def get_move
+
+  end
+end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -6,6 +6,6 @@ class Player
   end
 
   def get_move
-
+    'c2'
   end
 end

--- a/spec/board_test.rb
+++ b/spec/board_test.rb
@@ -47,4 +47,29 @@ class BoardTest < Minitest::Test
 
     assert_output(display_exp) { @test_board.display }
   end
+
+  def display_exp2
+    "   a     b     c\n" \
+    "      |     |\n" \
+    "1  X  |  -  |  -\n" \
+    " _____|_____|_____\n" \
+    "      |     |\n" \
+    "2  -  |  -  |  -\n" \
+    " _____|_____|_____\n" \
+    "      |     |\n" \
+    "3  -  |  -  |  -\n" \
+    "      |     |\n"
+  end
+
+  def test_display_board_with_single_computer_move
+    player = CompPlayer.new
+    current_player = 1
+
+    @test_board.process_move(
+      move: player.get_move(current_player: current_player),
+      current_player: current_player
+    )
+
+    assert_output(display_exp2) { @test_board.display }
+  end
 end

--- a/spec/comp_player_test.rb
+++ b/spec/comp_player_test.rb
@@ -15,6 +15,8 @@ class CompPlayerTest < Minitest::Test
   end
 
   def test_comp_player_gets_top_left_move
-    assert_equal('a1', @test_comp_player.get_move)
+    current_player = 1
+
+    assert_equal('a1', @test_comp_player.get_move(current_player: 1))
   end
 end

--- a/spec/comp_player_test.rb
+++ b/spec/comp_player_test.rb
@@ -6,14 +6,6 @@ class CompPlayerTest < Minitest::Test
     @test_comp_player = CompPlayer.new
   end
 
-  def test_create_comp_player
-    assert_instance_of(CompPlayer, @test_comp_player)
-  end
-
-  def test_comp_player_implements_get_move
-    assert_respond_to(@test_comp_player, :get_move)
-  end
-
   def test_comp_player_gets_top_left_move
     current_player = 1
 

--- a/spec/comp_player_test.rb
+++ b/spec/comp_player_test.rb
@@ -13,4 +13,8 @@ class CompPlayerTest < Minitest::Test
   def test_comp_player_implements_get_move
     assert_respond_to(@test_comp_player, :get_move)
   end
+
+  def test_comp_player_gets_top_left_move
+    assert_equal('a1', @test_comp_player.get_move)
+  end
 end

--- a/spec/comp_player_test.rb
+++ b/spec/comp_player_test.rb
@@ -1,11 +1,16 @@
 require 'minitest/autorun'
-
-CompPlayer = Struct.new(:foo)
+require_relative '../lib/comp_player'
 
 class CompPlayerTest < Minitest::Test
-  def test_create_comp_player
-    test_comp_player = CompPlayer.new
+  def setup
+    @test_comp_player = CompPlayer.new
+  end
 
-    assert_instance_of(CompPlayer, test_comp_player)
+  def test_create_comp_player
+    assert_instance_of(CompPlayer, @test_comp_player)
+  end
+
+  def test_comp_player_implements_get_move
+    assert_respond_to(@test_comp_player, :get_move)
   end
 end

--- a/spec/comp_player_test.rb
+++ b/spec/comp_player_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+
+CompPlayer = Struct.new(:foo)
+
+class CompPlayerTest < Minitest::Test
+  def test_create_comp_player
+    test_comp_player = CompPlayer.new
+
+    assert_instance_of(CompPlayer, test_comp_player)
+  end
+end

--- a/spec/game_test.rb
+++ b/spec/game_test.rb
@@ -4,6 +4,8 @@ require 'input_to_string_io'
 require 'minitest/autorun'
 require 'stringio'
 
+Player = Struct.new(:comp_player?)
+
 class GameTest < Minitest::Test
   include InputToStringIo
 
@@ -33,5 +35,11 @@ class GameTest < Minitest::Test
 
   def test_implements_current_player
     assert_respond_to(@test_game, :current_player)
+  end
+
+  def test_detect_comp_player
+    test_player = Player.new(true)
+
+    assert(test_player.comp_player?)
   end
 end

--- a/spec/game_test.rb
+++ b/spec/game_test.rb
@@ -1,10 +1,9 @@
 require 'game'
 require 'input_to_string_io'
 
+
 require 'minitest/autorun'
 require 'stringio'
-
-Player = Struct.new(:comp_player?)
 
 class GameTest < Minitest::Test
   include InputToStringIo
@@ -35,11 +34,5 @@ class GameTest < Minitest::Test
 
   def test_implements_current_player
     assert_respond_to(@test_game, :current_player)
-  end
-
-  def test_detect_comp_player
-    test_player = Player.new(true)
-
-    assert(test_player.comp_player?)
   end
 end

--- a/spec/mover_test.rb
+++ b/spec/mover_test.rb
@@ -17,11 +17,10 @@ class MoverTest < Minitest::Test
 
   def test_make_move
     $stdin = input_to_string_io('b1')
-    player = CompPlayer.new
     current_player = 1
 
-    exp = 'a1'
+    exp = 'b1'
 
-    assert_equal(exp, @test_mover.make_move(player: player, current_player: current_player))
+    assert_equal(exp, @test_mover.make_move(current_player))
   end
 end

--- a/spec/mover_test.rb
+++ b/spec/mover_test.rb
@@ -15,15 +15,13 @@ class MoverTest < Minitest::Test
     $stdin = STDIN
   end
 
-  def current_player
-    2
-  end
-
   def test_make_move
     $stdin = input_to_string_io('b1')
+    player = CompPlayer.new
+    current_player = 1
 
-    exp = 'b1'
+    exp = 'a1'
 
-    assert_equal(exp, @test_mover.make_move(current_player))
+    assert_equal(exp, @test_mover.make_move(player: player, current_player: current_player))
   end
 end

--- a/spec/player_test.rb
+++ b/spec/player_test.rb
@@ -9,10 +9,6 @@ class PlayerTest < Minitest::Test
     @test_player = Player.new
   end
 
-  def test_player_implements_get_move
-    assert_respond_to(@test_player, :get_move)
-  end
-
   def test_get_move
     $stdin = input_to_string_io('c2')
     current_player = 1

--- a/spec/player_test.rb
+++ b/spec/player_test.rb
@@ -6,11 +6,7 @@ require 'minitest/autorun'
 class PlayerTest < Minitest::Test
   include InputToStringIo
   def setup
-    @test_player = Player.new(true)
-  end
-
-  def test_detect_comp_player
-    assert(@test_player.comp_player)
+    @test_player = Player.new
   end
 
   def test_player_implements_get_move

--- a/spec/player_test.rb
+++ b/spec/player_test.rb
@@ -1,8 +1,10 @@
 require_relative '../lib/player'
+require_relative './helpers/input_to_string_io'
 
 require 'minitest/autorun'
 
 class PlayerTest < Minitest::Test
+  include InputToStringIo
   def setup
     @test_player = Player.new(true)
   end
@@ -16,6 +18,9 @@ class PlayerTest < Minitest::Test
   end
 
   def test_get_move
-    assert_equal('c2', @test_player.get_move)
+    $stdin = input_to_string_io('c2')
+    current_player = 1
+
+    assert_equal('c2', @test_player.get_move(current_player))
   end
 end

--- a/spec/player_test.rb
+++ b/spec/player_test.rb
@@ -1,0 +1,17 @@
+require_relative '../lib/player'
+
+require 'minitest/autorun'
+
+class PlayerTest < Minitest::Test
+  def setup
+    @test_player = Player.new(true)
+  end
+
+  def test_detect_comp_player
+    assert(@test_player.comp_player)
+  end
+
+  def test_player_implements_get_move
+    assert_respond_to(@test_player, :get_move)
+  end
+end

--- a/spec/player_test.rb
+++ b/spec/player_test.rb
@@ -14,4 +14,8 @@ class PlayerTest < Minitest::Test
   def test_player_implements_get_move
     assert_respond_to(@test_player, :get_move)
   end
+
+  def test_get_move
+    assert_equal('c2', @test_player.get_move)
+  end
 end


### PR DESCRIPTION
Please reference [Trello card](https://trello.com/c/VyIXFcHR/6-tic-tac-toe-the-computer-player-should-take-the-top-left-spot-on-an-empty-tic-tac-toe-board)

Add support for computer player always making a move in the top left square on an empty board

## Added

- Player and CompPlayer classes
- Tests for above classes

## Fixed

- Initially added computer move into program flow, then later removed so that integration tests still pass while computer logic is incomplete