### PR TITLE
Update tests to not print output to console

### DIFF
--- a/spec/game_test.rb
+++ b/spec/game_test.rb
@@ -9,6 +9,7 @@ class GameTest < Minitest::Test
 
   def setup
     @test_game = Game.new
+    $stdout = StringIO.new
   end
 
   def teardown

--- a/spec/mover_test.rb
+++ b/spec/mover_test.rb
@@ -8,6 +8,7 @@ class MoverTest < Minitest::Test
 
   def setup
     @test_mover = Mover.new
+    $stdout = StringIO.new
   end
 
   def teardown


### PR DESCRIPTION
Please reference [Trello card](https://trello.com/c/WtyHQ44N/11-tic-tac-toe-refactor-to-remove-extraneous-test-output)

Redirect test output to stringio

## Added

- Assign a stringio to `$stdout` in game_test and mover_test to capture test output and keep it from obscuring the test results

Pair: @kevbuchanan